### PR TITLE
Preserve evaluation metadata during dataset merging

### DIFF
--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -3,8 +3,14 @@ import sys
 import time
 from pathlib import Path
 
+import pandas as pd
+
 sys.path.append(str(Path(__file__).resolve().parents[1]))
-from src.utils.formatter import list_audios, find_latest_best_model
+from src.utils.formatter import (
+    list_audios,
+    find_latest_best_model,
+    merge_and_split_metadata,
+)
 
 
 def test_list_audios(tmp_path):
@@ -29,3 +35,35 @@ def test_find_latest_best_model(tmp_path):
     f2.write_text("b")
     result = find_latest_best_model(str(tmp_path))
     assert result == str(f2)
+
+
+def test_merge_and_split_metadata(tmp_path):
+    train_csv = tmp_path / "metadata_train.csv"
+    eval_csv = tmp_path / "metadata_eval.csv"
+
+    pd.DataFrame(
+        [
+            {"audio_file": "wavs/a.wav", "text": "a", "speaker_name": "spk"},
+            {"audio_file": "wavs/b.wav", "text": "b", "speaker_name": "spk"},
+        ]
+    ).to_csv(train_csv, sep="|", index=False)
+    eval_csv.touch()
+
+    existing_train = pd.DataFrame(
+        [{"audio_file": "wavs/c.wav", "text": "c", "speaker_name": "spk"}]
+    )
+    existing_eval = pd.DataFrame(
+        [{"audio_file": "wavs/d.wav", "text": "d", "speaker_name": "spk"}]
+    )
+
+    merge_and_split_metadata(
+        str(train_csv), str(eval_csv), existing_train, existing_eval, 0.5
+    )
+
+    final_train = pd.read_csv(train_csv, sep="|")
+    final_eval = pd.read_csv(eval_csv, sep="|")
+
+    assert "wavs/d.wav" in final_eval["audio_file"].tolist()
+    assert set(final_train["audio_file"]).isdisjoint(
+        set(final_eval["audio_file"])
+    )


### PR DESCRIPTION
## Summary
- preserve existing evaluation metadata when merging new segments
- add helper to rebuild train/eval splits without overlap
- cover metadata merge logic with unit test

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae89547e548332bf03a7ce721c29d9